### PR TITLE
feat: add timeout flag with context cancellation

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Parâmetros no formato `flag` / `variável de ambiente`.
 - `--smtp-destinations` / `SMTP_DESTINATIONS`: lista de e-mails para enviar os resultados separada por espaço
 - `--sentry-dsn` / `SENTRY_DSN`: DSN do Sentry para monitoramento de erros
 - `--proxy` / `SELENIUM_PROXY_SERVER`: servidor proxy para o Selenium
+- `--timeout` / `TIMEOUT`: tempo máximo total de execução antes de cancelar o trabalho, padrão: 10 minutos
 - `--headless` (apenas flag): rodar o navegador em modo headless (sem interface gráfica), padrão em containers
 - `--verbose` (apenas flag): dar mais detalhes sobre o que está acontecendo, bom para debug
 - `--version`: exibe a versão do programa

--- a/app.go
+++ b/app.go
@@ -40,6 +40,16 @@ type App struct {
 	ChromiumPath     string
 }
 
+func sleepContext(ctx context.Context, d time.Duration) {
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+
+	select {
+	case <-ctx.Done():
+	case <-timer.C:
+	}
+}
+
 func (a *App) Run(ctx context.Context) error {
 	// Setup Sentry
 	a.setupSentry()
@@ -76,21 +86,25 @@ func (a *App) Run(ctx context.Context) error {
 	defer browser.MustClose()
 
 	// Login
-	page, err := a.loginToFusionSolar(browser)
+	page, err := a.loginToFusionSolar(ctx, browser)
 	if err != nil {
 		sentry.CaptureException(err)
 		return err
 	}
 
 	// Get Stations
-	stationsData, err := a.getStations(page)
+	stationsData, err := a.getStations(ctx, page)
 	if err != nil {
 		sentry.CaptureException(err)
 		return err
 	}
 
 	// Collect Data
-	emailBody, attachments := a.collectStationData(page, stationsData)
+	emailBody, attachments, err := a.collectStationData(ctx, page, stationsData)
+	if err != nil {
+		sentry.CaptureException(err)
+		return err
+	}
 
 	fmt.Println(emailBody)
 
@@ -169,20 +183,26 @@ func (a *App) setupBrowser() *rod.Browser {
 	return browser.MustConnect()
 }
 
-func (a *App) loginToFusionSolar(browser *rod.Browser) (*rod.Page, error) {
+func (a *App) loginToFusionSolar(ctx context.Context, browser *rod.Browser) (*rod.Page, error) {
 	for i := 0; i < a.MaxLoginRetries; i++ {
 		slog.Info(fmt.Sprintf("[*] Login attempt %d/%d", i+1, a.MaxLoginRetries))
 		page := browser.MustPage("https://intl.fusionsolar.huawei.com/pvmswebsite/login/build/index.html#/LOGIN")
 
 		page.MustWaitLoad()
-		time.Sleep(5 * time.Second)
+		sleepContext(ctx, 5*time.Second)
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 
 		page.MustElement("div#username input").MustInput(a.User)
 		passwordInput := page.MustElement("div#password input")
 		passwordInput.MustInput(a.Password)
 		passwordInput.MustType(input.Enter)
 
-		time.Sleep(10 * time.Second)
+		sleepContext(ctx, 10*time.Second)
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 
 		// Handle cookie dialog
 		cookieButtons := page.MustElements("i.cookiePolicy-icon")
@@ -200,9 +220,15 @@ func (a *App) loginToFusionSolar(browser *rod.Browser) (*rod.Page, error) {
 
 			approveBtn, err := modal.Element("button.dpdesign-btn-primary")
 			if err == nil {
-				time.Sleep(1 * time.Second)
+				sleepContext(ctx, 1*time.Second)
+				if err := ctx.Err(); err != nil {
+					return nil, err
+				}
 				approveBtn.MustClick()
-				time.Sleep(10 * time.Second)
+				sleepContext(ctx, 10*time.Second)
+				if err := ctx.Err(); err != nil {
+					return nil, err
+				}
 			}
 		}
 
@@ -221,7 +247,7 @@ type StationData struct {
 	Name string
 }
 
-func (a *App) getStations(page *rod.Page) ([]StationData, error) {
+func (a *App) getStations(ctx context.Context, page *rod.Page) ([]StationData, error) {
 	maxAttempts := 5
 	attempts := 0
 	var stationsData []StationData
@@ -229,7 +255,10 @@ func (a *App) getStations(page *rod.Page) ([]StationData, error) {
 	for len(stationsData) == 0 && attempts < maxAttempts {
 		slog.Info("[*] Acessando homepage")
 		page.MustNavigate("https://intl.fusionsolar.huawei.com")
-		time.Sleep(10 * time.Second)
+		sleepContext(ctx, 10*time.Second)
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 
 		slog.Info("[*] Tentando listar estações")
 		stations, err := page.Elements("a.nco-home-list-text-ellipsis")
@@ -263,7 +292,7 @@ type Attachment struct {
 	Content []byte
 }
 
-func (a *App) collectStationData(page *rod.Page, stationsData []StationData) (string, []Attachment) {
+func (a *App) collectStationData(ctx context.Context, page *rod.Page, stationsData []StationData) (string, []Attachment, error) {
 	var emailBody strings.Builder
 	emailBody.WriteString("Quantidade de energia produzida em cada base\n\n")
 	var attachments []Attachment
@@ -271,7 +300,10 @@ func (a *App) collectStationData(page *rod.Page, stationsData []StationData) (st
 	for _, station := range stationsData {
 		slog.Info(fmt.Sprintf("[*] Coletando dados da estação \"%s\"", station.Name))
 		page.MustNavigate(station.URL)
-		time.Sleep(10 * time.Second)
+		sleepContext(ctx, 10*time.Second)
+		if err := ctx.Err(); err != nil {
+			return emailBody.String(), attachments, err
+		}
 
 		// Get canvas chart
 		canvas := page.MustElement(".nco-single-energy-body canvas")
@@ -310,7 +342,7 @@ func (a *App) collectStationData(page *rod.Page, stationsData []StationData) (st
 	fmt.Fprintf(&emailBody, "\nOs gráficos de geração estão em anexo.\n\n")
 	fmt.Fprintf(&emailBody, "Dados obtidos em: %s\n", time.Now().Format("2006-01-02 15:04:05"))
 
-	return emailBody.String(), attachments
+	return emailBody.String(), attachments, nil
 }
 
 func (a *App) sendEmail(subject, body string, attachments []Attachment) {

--- a/app_test.go
+++ b/app_test.go
@@ -1,0 +1,18 @@
+package fusionsolar
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestSleepContextStopsWhenContextIsCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	start := time.Now()
+	sleepContext(ctx, 30*time.Second)
+	if elapsed := time.Since(start); elapsed > 50*time.Millisecond {
+		t.Fatalf("sleepContext should return immediately on cancellation, took %s", elapsed)
+	}
+}

--- a/cmd/fusionsolar-bot/root.go
+++ b/cmd/fusionsolar-bot/root.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"strings"
+	"time"
 
 	fusionsolar "fusionsolar-bot"
 
@@ -27,6 +28,7 @@ var (
 	headless         bool
 	verbose          bool
 	version          bool
+	timeout          time.Duration
 	maxLoginRetries  int
 )
 
@@ -69,6 +71,7 @@ func init() {
 	rootCmd.Flags().BoolVar(&headless, "headless", defaultHeadless, "Run Chrome in headless mode")
 	rootCmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Enable verbose logging")
 	rootCmd.Flags().BoolVar(&version, "version", false, "Print version and exit")
+	rootCmd.Flags().DurationVar(&timeout, "timeout", 10*time.Minute, "Maximum total runtime before cancellation")
 	rootCmd.Flags().IntVar(&maxLoginRetries, "max-login-retries", 5, "Maximum number of login retries")
 
 	bindFlags()
@@ -84,6 +87,7 @@ func bindFlags() {
 	viper.BindPFlag("smtp-destinations", rootCmd.Flags().Lookup("smtp-destinations"))
 	viper.BindPFlag("sentry-dsn", rootCmd.Flags().Lookup("sentry-dsn"))
 	viper.BindPFlag("proxy", rootCmd.Flags().Lookup("proxy"))
+	viper.BindPFlag("timeout", rootCmd.Flags().Lookup("timeout"))
 	viper.BindPFlag("max-login-retries", rootCmd.Flags().Lookup("max-login-retries"))
 	// Headless and verbose are flags only, usually, but we can bind them if we want env vars support for them too.
 	// The python script didn't seem to use env vars for headless/verbose, but `args = parser.parse_args()` was used.
@@ -115,6 +119,7 @@ func initConfig() {
 	viper.BindEnv("smtp-destinations", "SMTP_DESTINATIONS")
 	viper.BindEnv("sentry-dsn", "SENTRY_DSN")
 	viper.BindEnv("proxy", "SELENIUM_PROXY_SERVER")
+	viper.BindEnv("timeout", "TIMEOUT")
 	viper.BindEnv("max-login-retries", "MAX_LOGIN_RETRIES")
 	viper.BindEnv("chromium-path", "CHROMIUM")
 
@@ -124,6 +129,13 @@ func initConfig() {
 }
 
 func runBot() {
+	runTimeout := viper.GetDuration("timeout")
+	if runTimeout <= 0 {
+		runTimeout = 10 * time.Minute
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), runTimeout)
+	defer cancel()
+
 	destinationsStr := viper.GetString("smtp-destinations")
 	destinations := strings.FieldsFunc(destinationsStr, func(r rune) bool {
 		return r == ',' || r == ' '
@@ -145,7 +157,7 @@ func runBot() {
 		ChromiumPath:     viper.GetString("chromium-path"),
 	}
 
-	if err := app.Run(context.Background()); err != nil {
+	if err := app.Run(ctx); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/cmd/fusionsolar-bot/root_test.go
+++ b/cmd/fusionsolar-bot/root_test.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+func TestTimeoutFlagDefaultsToTenMinutes(t *testing.T) {
+	flag := rootCmd.Flags().Lookup("timeout")
+	if flag == nil {
+		t.Fatal("timeout flag is not defined")
+	}
+
+	got, err := time.ParseDuration(flag.DefValue)
+	if err != nil {
+		t.Fatalf("failed to parse timeout default %q: %v", flag.DefValue, err)
+	}
+
+	if got != 10*time.Minute {
+		t.Fatalf("expected timeout default to be 10m, got %s", got)
+	}
+}


### PR DESCRIPTION
## Summary
- adiciona a flag `--timeout` com padrão de `10m`
- aplica `context.WithTimeout` no fluxo principal
- torna os waits do fluxo sensíveis ao contexto
- documenta a nova flag no README

## Testes
- `mise exec -- go test ./... -v`

## Observações
O timeout encerra a execução inteira quando expira, usando o padrão já existente de `context` no projeto.
