### PR TITLE
feat: use external CDP browser only

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,9 +11,7 @@ RUN go build -o fusionsolar-bot ./cmd/fusionsolar-bot
 
 FROM alpine:latest@sha256:865b95f46d98cf867a156fe4a135ad3fe50d2056aa3f25ed31662dff6da4eb62
 
-RUN apk add --no-cache chromium ca-certificates
-
-ENV CHROMIUM=/usr/bin/chromium-browser
+RUN apk add --no-cache ca-certificates
 
 COPY --from=builder /app/fusionsolar-bot /usr/local/bin/fusionsolar-bot
 

--- a/README.md
+++ b/README.md
@@ -44,9 +44,42 @@ fusionsolar-bot [parametros]
 ### GitHub Actions
 Considerado experimental.
 
-Por algum motivo o sistema não consegue acessar o fusionsolar pelo GitHub Actions. Cheguei a tentar pelo Tor sem muito sucesso.
+Se quiser usar a action do repositório, a forma mais simples é subir um Browserless como *service* no workflow e passar o endpoint CDP para a action.
 
-O workflow, na fase de configurar o sistema que oculta os secrets, acaba mostrando os secrets :facepalm:
+Exemplo:
+
+```yaml
+name: fusionsolar-report
+on:
+  workflow_dispatch:
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    services:
+      browserless:
+        image: browserless/chrome:latest
+        ports:
+          - 3000:3000
+        options: >-
+          --shm-size=1g
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run fusionsolar report
+        uses: lucasew/fusionsolar-bot@vX
+        with:
+          user: ${{ secrets.FUSIONSOLAR_USER }}
+          password: ${{ secrets.FUSIONSOLAR_PASSWORD }}
+          browser_cdp: ws://browserless:3000/devtools/browser/SEU_ID_AQUI
+          smtp_user: ${{ secrets.SMTP_USER }}
+          smtp_passwd: ${{ secrets.SMTP_PASSWD }}
+          smtp_server: ${{ secrets.SMTP_SERVER }}
+          smtp_destinations: ${{ secrets.SMTP_DESTINATIONS }}
+```
+
+O ponto importante é que a action *não* sobe o browser sozinha: ela só recebe o `browser_cdp`. Se você preferir outro backend compatível com CDP, basta trocar o service e a URL.
 
 ## Parâmetros
 Esse projeto faz basicamente duas coisas:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Puxa os dados de produção do dia do Fusion Solar e manda para a lista de e-mai
 Para rodar a versão mais recente diretamente do registro:
 
 ```bash
-docker run ghcr.io/lucasew/fusionsolar-bot:latest [parametros]
+docker run -e BROWSER_CDP="ws://browserless:3000/devtools/browser/abc123" ghcr.io/lucasew/fusionsolar-bot:latest [parametros]
 ```
 
 Para construir a imagem localmente:
@@ -20,7 +20,7 @@ docker build -t fusionsolar-bot .
 E para rodar a imagem construída localmente:
 
 ```bash
-docker run fusionsolar-bot [parametros]
+docker run -e BROWSER_CDP="ws://browserless:3000/devtools/browser/abc123" fusionsolar-bot [parametros]
 ```
 
 Nenhum estado desse container precisa ser salvo.
@@ -28,7 +28,7 @@ Nenhum estado desse container precisa ser salvo.
 ### Go (Binário/Source)
 Este projeto usa o [mise](https://mise.jdx.dev) para gerenciar a versão do Go. Se você tiver o `mise` instalado, basta entrar na pasta do projeto e ele baixará a versão correta do Go automaticamente.
 
-Você ainda precisará do navegador Chromium/Chrome instalado no sistema.
+Este projeto depende de um navegador exposto via CDP. Configure a variável `BROWSER_CDP` com a URL do endpoint antes de rodar.
 
 Para rodar diretamente do código fonte:
 ```bash
@@ -65,9 +65,8 @@ Parâmetros no formato `flag` / `variável de ambiente`.
 - `--smtp-server` / `SMTP_SERVER`: servidor SMTP para envio do email (host:port)
 - `--smtp-destinations` / `SMTP_DESTINATIONS`: lista de e-mails para enviar os resultados separada por espaço
 - `--sentry-dsn` / `SENTRY_DSN`: DSN do Sentry para monitoramento de erros
-- `--proxy` / `SELENIUM_PROXY_SERVER`: servidor proxy para o Selenium
 - `--timeout` / `TIMEOUT`: tempo máximo total de execução antes de cancelar o trabalho, padrão: 10 minutos
-- `--headless` (apenas flag): rodar o navegador em modo headless (sem interface gráfica), padrão em containers
+- `--browser-cdp` / `BROWSER_CDP`: endpoint CDP do navegador remoto (obrigatório)
 - `--verbose` (apenas flag): dar mais detalhes sobre o que está acontecendo, bom para debug
 - `--version`: exibe a versão do programa
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Puxa os dados de produção do dia do Fusion Solar e manda para a lista de e-mai
 Para rodar a versão mais recente diretamente do registro:
 
 ```bash
-docker run -e BROWSER_CDP="ws://browserless:3000/devtools/browser/abc123" ghcr.io/lucasew/fusionsolar-bot:latest [parametros]
+docker run -e BROWSER_CDP="ws://your-cdp-endpoint:9222/devtools/browser/abc123" ghcr.io/lucasew/fusionsolar-bot:latest [parametros]
 ```
 
 Para construir a imagem localmente:
@@ -20,7 +20,7 @@ docker build -t fusionsolar-bot .
 E para rodar a imagem construída localmente:
 
 ```bash
-docker run -e BROWSER_CDP="ws://browserless:3000/devtools/browser/abc123" fusionsolar-bot [parametros]
+docker run -e BROWSER_CDP="ws://your-cdp-endpoint:9222/devtools/browser/abc123" fusionsolar-bot [parametros]
 ```
 
 Nenhum estado desse container precisa ser salvo.

--- a/action.yml
+++ b/action.yml
@@ -11,7 +11,7 @@ inputs:
     description: Password for the fusionsolar user
     required: true
   browser_cdp:
-    description: CDP endpoint for the remote browser
+    description: CDP endpoint for an already running remote browser (the action does not start Browserless)
     required: true
   smtp_user:
     description: User for SMTP server to send the email

--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,9 @@ inputs:
   password:
     description: Password for the fusionsolar user
     required: true
+  browser_cdp:
+    description: CDP endpoint for the remote browser
+    required: true
   smtp_user:
     description: User for SMTP server to send the email
   smtp_passwd:
@@ -21,10 +24,6 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Setup tor for proxying
-      uses: tor-actions/setup-tor@main
-      with:
-        daemon: true
     - name: Get container tag
       shell: bash
       run: |
@@ -34,6 +33,7 @@ runs:
       run: |
         echo "::add-mask::${{ inputs.user }}"
         echo "::add-mask::${{ inputs.password }}"
+        echo "::add-mask::${{ inputs.browser_cdp }}"
         echo "::add-mask::${{ inputs.smtp_user }}"
         echo "::add-mask::${{ inputs.smtp_passwd }}"
         echo "::add-mask::${{ inputs.smtp_server }}"
@@ -41,11 +41,8 @@ runs:
     - name: Run fusionsolar workflow in one go
       shell: bash
       run: |
-        
         docker run -i \
-          --dns=1.1.1.1 \
-          --net=host \
-          -e SELENIUM_PROXY_SERVER=localhost:9050 \
+          -e BROWSER_CDP="${{ inputs.browser_cdp }}" \
           -e FUSIONSOLAR_USER="${{ inputs.user }}" \
           -e FUSIONSOLAR_PASSWORD="${{ inputs.password }}" \
           -e SMTP_USER="${{ inputs.smtp_user }}" \

--- a/app.go
+++ b/app.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"log/slog"
 	"net"
-	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -18,7 +17,6 @@ import (
 	"github.com/go-rod/rod"
 
 	"github.com/go-rod/rod/lib/input"
-	"github.com/go-rod/rod/lib/launcher"
 )
 
 //go:embed version.txt
@@ -33,11 +31,9 @@ type App struct {
 	SmtpServer       string
 	SmtpDestinations []string
 	SentryDsn        string
-	Proxy            string
-	Headless         bool
+	BrowserCDP       string
 	Verbose          bool
 	MaxLoginRetries  int
-	ChromiumPath     string
 }
 
 func sleepContext(ctx context.Context, d time.Duration) {
@@ -82,7 +78,10 @@ func (a *App) Run(ctx context.Context) error {
 	}
 
 	// Setup Browser
-	browser := a.setupBrowser().Context(ctx)
+	browser, err := a.setupBrowser(ctx)
+	if err != nil {
+		return err
+	}
 	defer browser.MustClose()
 
 	// Login
@@ -139,48 +138,18 @@ func (a *App) setupSentry() {
 	}
 }
 
-func (a *App) setupBrowser() *rod.Browser {
-	l := launcher.New()
-
-	if a.ChromiumPath != "" {
-		l.Bin(a.ChromiumPath)
-	} else {
-		// Try to find the browser if env is not set
-		if path, _ := launcher.LookPath(); path != "" {
-			l.Bin(path)
-		} else {
-			// Fallback for alpine
-			if _, err := os.Stat("/usr/bin/chromium-browser"); err == nil {
-				l.Bin("/usr/bin/chromium-browser")
-			}
-		}
+func (a *App) setupBrowser(ctx context.Context) (*rod.Browser, error) {
+	if a.BrowserCDP == "" {
+		return nil, fmt.Errorf("[!] BROWSER_CDP não fornecido")
 	}
 
-	if a.Headless {
-		l = l.Headless(true).
-			Set("disable-gpu").
-			Set("disable-dev-shm-usage").
-			Set("disable-setuid-sandbox").
-			Set("no-sandbox")
-	} else {
-		l = l.Headless(false)
-	}
-
-	if a.Proxy != "" {
-		l = l.Proxy(a.Proxy)
-	}
-
-	l = l.Set("window-size", "1280,720")
-
-	u := l.MustLaunch()
-
-	browser := rod.New().ControlURL(u)
+	browser := rod.New().Context(ctx).ControlURL(a.BrowserCDP)
 
 	if a.Verbose {
 		browser = browser.Trace(true)
 	}
 
-	return browser.MustConnect()
+	return browser, browser.Connect()
 }
 
 func (a *App) loginToFusionSolar(ctx context.Context, browser *rod.Browser) (*rod.Page, error) {

--- a/cmd/fusionsolar-bot/root.go
+++ b/cmd/fusionsolar-bot/root.go
@@ -24,8 +24,7 @@ var (
 	smtpServer       string
 	smtpDestinations string
 	sentryDsn        string
-	proxy            string
-	headless         bool
+	browserCDP       string
 	verbose          bool
 	version          bool
 	timeout          time.Duration
@@ -35,7 +34,7 @@ var (
 var rootCmd = &cobra.Command{
 	Use:   "fusionsolar-bot",
 	Short: "FusionSolar data collector",
-	Long:  `A bot to collect data from FusionSolar and send reports via email.`,
+	Long:  `A bot to collect data from FusionSolar and send reports via email using an external CDP browser.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if version {
 			fmt.Println(fusionsolar.Version)
@@ -65,10 +64,7 @@ func init() {
 	rootCmd.Flags().StringVar(&smtpServer, "smtp-server", "", "SMTP server (format: server:port)")
 	rootCmd.Flags().StringVar(&smtpDestinations, "smtp-destinations", "", "Email recipients (space separated)")
 	rootCmd.Flags().StringVar(&sentryDsn, "sentry-dsn", "", "Sentry DSN for error tracking")
-	rootCmd.Flags().StringVar(&proxy, "proxy", "", "Proxy server for Selenium")
-
-	defaultHeadless := os.Getenv("DISPLAY") == ""
-	rootCmd.Flags().BoolVar(&headless, "headless", defaultHeadless, "Run Chrome in headless mode")
+	rootCmd.Flags().StringVar(&browserCDP, "browser-cdp", "", "CDP endpoint for the browser")
 	rootCmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Enable verbose logging")
 	rootCmd.Flags().BoolVar(&version, "version", false, "Print version and exit")
 	rootCmd.Flags().DurationVar(&timeout, "timeout", 10*time.Minute, "Maximum total runtime before cancellation")
@@ -86,13 +82,9 @@ func bindFlags() {
 	viper.BindPFlag("smtp-server", rootCmd.Flags().Lookup("smtp-server"))
 	viper.BindPFlag("smtp-destinations", rootCmd.Flags().Lookup("smtp-destinations"))
 	viper.BindPFlag("sentry-dsn", rootCmd.Flags().Lookup("sentry-dsn"))
-	viper.BindPFlag("proxy", rootCmd.Flags().Lookup("proxy"))
 	viper.BindPFlag("timeout", rootCmd.Flags().Lookup("timeout"))
+	viper.BindPFlag("browser-cdp", rootCmd.Flags().Lookup("browser-cdp"))
 	viper.BindPFlag("max-login-retries", rootCmd.Flags().Lookup("max-login-retries"))
-	// Headless and verbose are flags only, usually, but we can bind them if we want env vars support for them too.
-	// The python script didn't seem to use env vars for headless/verbose, but `args = parser.parse_args()` was used.
-	// The python script had `default=os.getenv(...)` for some args.
-	// Cobra+Viper handles this by checking flag -> env -> config -> default.
 }
 
 func initConfig() {
@@ -118,10 +110,9 @@ func initConfig() {
 	viper.BindEnv("smtp-server", "SMTP_SERVER")
 	viper.BindEnv("smtp-destinations", "SMTP_DESTINATIONS")
 	viper.BindEnv("sentry-dsn", "SENTRY_DSN")
-	viper.BindEnv("proxy", "SELENIUM_PROXY_SERVER")
 	viper.BindEnv("timeout", "TIMEOUT")
+	viper.BindEnv("browser-cdp", "BROWSER_CDP")
 	viper.BindEnv("max-login-retries", "MAX_LOGIN_RETRIES")
-	viper.BindEnv("chromium-path", "CHROMIUM")
 
 	if err := viper.ReadInConfig(); err == nil {
 		fmt.Println("Using config file:", viper.ConfigFileUsed())
@@ -150,11 +141,9 @@ func runBot() {
 		SmtpServer:       viper.GetString("smtp-server"),
 		SmtpDestinations: destinations,
 		SentryDsn:        viper.GetString("sentry-dsn"),
-		Proxy:            viper.GetString("proxy"),
-		Headless:         headless,
+		BrowserCDP:       viper.GetString("browser-cdp"),
 		Verbose:          verbose,
 		MaxLoginRetries:  viper.GetInt("max-login-retries"),
-		ChromiumPath:     viper.GetString("chromium-path"),
 	}
 
 	if err := app.Run(ctx); err != nil {


### PR DESCRIPTION
## Resumo
- remove suporte a subir Chrome local / launcher
- exige `BROWSER_CDP` para conectar no navegador remoto via CDP
- deixa a imagem Docker mínima, sem Chromium
- atualiza README e `action.yml` para o fluxo CDP-only

## Validação
- `mise exec -- go test ./...`
