### PR TITLE
docs: fix Browserless CDP example for GitHub Actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,12 +41,16 @@ go install ./cmd/fusionsolar-bot
 fusionsolar-bot [parametros]
 ```
 
-### GitHub Actions
+### Browserless / CDP
 Considerado experimental.
 
-Se quiser usar a action do repositório, a forma mais simples é subir um Browserless como *service* no workflow e passar o endpoint CDP para a action.
+Quando a aplicação usa Browserless como navegador remoto, a sessão pode expirar no meio da coleta de uma estação. O `timeout` do Browserless é em *milissegundos*; se precisar aumentar o tempo, passe o query param na URL CDP, por exemplo:
 
-Exemplo:
+```text
+wss://browserless:3000?timeout=120000
+```
+
+O problema observado aqui não é o GitHub Actions em si, e sim a sessão do browser remoto sendo encerrada antes de terminar a coleta.
 
 ```yaml
 name: fusionsolar-report

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ jobs:
         with:
           user: ${{ secrets.FUSIONSOLAR_USER }}
           password: ${{ secrets.FUSIONSOLAR_PASSWORD }}
-          browser_cdp: ws://browserless:3000/devtools/browser/SEU_ID_AQUI
+          browser_cdp: ws://browserless:3000
           smtp_user: ${{ secrets.SMTP_USER }}
           smtp_passwd: ${{ secrets.SMTP_PASSWD }}
           smtp_server: ${{ secrets.SMTP_SERVER }}


### PR DESCRIPTION
## Resumo
- esclarece que o problema observado é timeout da sessão Browserless durante a coleta de uma estação
- indica que o `timeout` do Browserless é em milissegundos
- sugere passar `?timeout=120000` na URL CDP quando usar Browserless como navegador remoto

## Contexto
Esse PR é separado da mudança principal de CDP-only e fica focado só na documentação do Browserless.
